### PR TITLE
New good: basket

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -5,15 +5,16 @@ use crate::goods::Good;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Action {
-    ProduceBerries,
-    ProduceBasket,
+    // ProduceBerries,
+    // ProduceBasket,
+    ProduceGood(Good),
     Leisure,
 }
 
 impl Action {
     pub fn random<R: Rng + ?Sized>(rng: &mut R) -> Self {
         match rng.random_range(0..=1) {
-            0 => Action::ProduceBerries,
+            0 => Action::ProduceGood(Good::Berries),
             1 => Action::Leisure,
             _ => unreachable!(),
         }
@@ -21,7 +22,7 @@ impl Action {
 
     pub fn random_weighted<R: Rng + ?Sized>(rng: &mut R, prob_produce_berries: f64) -> Self {
         if rng.random::<f64>() < prob_produce_berries {
-            Action::ProduceBerries
+            Action::ProduceGood(Good::Berries)
         } else {
             Action::Leisure
         }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,9 +1,12 @@
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
+use crate::goods::Good;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Action {
     ProduceBerries,
+    ProduceBasket,
     Leisure,
 }
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -5,8 +5,6 @@ use crate::goods::Good;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Action {
-    // ProduceBerries,
-    // ProduceBasket,
     ProduceGood(Good),
     Leisure,
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -65,12 +65,20 @@ impl Agent for CrusoeAgent {
         &self.stock
     }
 
+    // TODO: Some capital goods take multiple time units to produce.
     fn productivity(&self, good: Good) -> UInt {
         // TODO: make configurable.
         match good {
             Good::Berries {
                 remaining_lifetime: _,
-            } => 4, // 4 units per day.
+            } => {
+                // TODO.
+                // if self.stock.contains(Good::Basket { remaining_uses: _ }) {
+                //     return 8;
+                // }
+                return 4;
+            }
+            Good::Basket { remaining_uses: _ } => 1,
         }
     }
 
@@ -136,8 +144,10 @@ impl Agent for CrusoeAgent {
                     },
                     productivity,
                 );
-            } // increase stock by `productivity` units of berries.
-            Action::Leisure => (), // do nothing
+            }
+            Action::Leisure => (),
+            // TODO.
+            Action::ProduceBasket => todo!(),
         }
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -27,7 +27,7 @@ pub trait Agent {
     fn history(&self) -> Vec<Action>;
     /// Return true if the agent is still alive.
     fn is_alive(&self) -> bool;
-    /// Update
+    /// Execture the given action.
     fn act(&mut self, action: Action);
     /// Step the agent forward by one time step.
     fn step_forward(&mut self);
@@ -77,6 +77,14 @@ impl Agent for CrusoeAgent {
                 return 4;
             }
             Good::Basket => 1,
+            Good::Fish => {
+                // Productivity of fish is increased by access to a spear.
+                if self.stock.contains(Good::Spear) {
+                    return 10;
+                }
+                return 2;
+            }
+            Good::Spear => 1,
         }
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -7,7 +7,7 @@ use rand::rngs::StdRng;
 use serde::{Deserialize, Serialize};
 
 use crate::actions::Action;
-use crate::goods::Good;
+use crate::goods::{Good, GoodsUnit};
 use crate::stock::Stock;
 use crate::{Int, UInt};
 
@@ -69,16 +69,14 @@ impl Agent for CrusoeAgent {
     fn productivity(&self, good: Good) -> UInt {
         // TODO: make configurable.
         match good {
-            Good::Berries {
-                remaining_lifetime: _,
-            } => {
+            Good::Berries => {
                 // TODO.
                 // if self.stock.contains(Good::Basket { remaining_uses: _ }) {
                 //     return 8;
                 // }
                 return 4;
             }
-            Good::Basket { remaining_uses: _ } => 1,
+            Good::Basket => 1,
         }
     }
 
@@ -134,20 +132,11 @@ impl Agent for CrusoeAgent {
 
     fn act(&mut self, action: Action) {
         match action {
-            Action::ProduceBerries => {
-                let productivity = self.productivity(Good::Berries {
-                    remaining_lifetime: 0,
-                });
-                self.stock.add(
-                    Good::Berries {
-                        remaining_lifetime: 10,
-                    },
-                    productivity,
-                );
+            Action::ProduceGood(good) => {
+                let qty = self.productivity(good);
+                self.stock.add(GoodsUnit::new(&good), qty);
             }
             Action::Leisure => (),
-            // TODO.
-            Action::ProduceBasket => todo!(),
         }
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -29,7 +29,7 @@ pub trait Agent {
     fn is_alive(&self) -> bool;
     /// Update
     fn act(&mut self, action: Action);
-    ///
+    /// Step the agent forward by one time step.
     fn step_forward(&mut self);
 }
 
@@ -145,6 +145,7 @@ impl Agent for CrusoeAgent {
         let action = self.choose_action();
         // Perform action, which updates the agent's stock
         self.act(action);
+        // Degrade the agent's stock.
         self.stock.step_forward(action);
         // Consume stock, which updates whether the agent is alive
         // TODO: make required nutritional_units per time unit configurable.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,7 +1,4 @@
-use std::collections::HashMap;
-
 use enum_dispatch::enum_dispatch;
-use itertools::Itertools;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use serde::{Deserialize, Serialize};

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -70,10 +70,10 @@ impl Agent for CrusoeAgent {
         // TODO: make configurable.
         match good {
             Good::Berries => {
-                // TODO.
-                // if self.stock.contains(Good::Basket { remaining_uses: _ }) {
-                //     return 8;
-                // }
+                // Productivity of berries is increased by access to a basket.
+                if self.stock.contains(Good::Basket) {
+                    return 8;
+                }
                 return 4;
             }
             Good::Basket => 1,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -146,6 +146,7 @@ impl Agent for CrusoeAgent {
         let action = self.choose_action();
         // Perform action, which updates the agent's stock
         self.act(action);
+        self.stock.step_forward(action);
         // Consume stock, which updates whether the agent is alive
         // TODO: make required nutritional_units per time unit configurable.
         self.is_alive = self.consume(1);

--- a/src/goods.rs
+++ b/src/goods.rs
@@ -7,30 +7,51 @@ use crate::UInt;
 pub enum Good {
     Berries,
     Basket,
+    // Spear,
+    // Smoker,
+    // Boat,
+    // Timber,
+    // Axe,
 }
+
+// // For units of goods, each has a lifetime remaining value before it is destroyed.
+// // For capital goods, (e.g. spear, timber), each has a number of uses remaining before it is destroyed.
+// #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+// pub enum GoodsUnit {
+//     Berries { remaining_lifetime: UInt },
+//     // Fish{ remaining_lifetime: UInt },
+//     Basket { remaining_uses: UInt },
+//     // Spear{ remaining_uses: UInt },
+//     // Smoker{ remaining_uses: UInt },
+//     // Boat{ remaining_uses: UInt },
+//     // Timber,
+//     // Axe,
+// }
 
 // For units of goods, each has a lifetime remaining value before it is destroyed.
 // For capital goods, (e.g. spear, timber), each has a number of uses remaining before it is destroyed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum GoodsUnit {
-    Berries { remaining_lifetime: UInt },
-    // Fish{ remaining_lifetime: UInt },
-    Basket { remaining_uses: UInt },
-    // Spear{ remaining_uses: UInt },
-    // Smoker{ remaining_uses: UInt },
-    // Boat{ remaining_uses: UInt },
-    // Timber,
-    // Axe,
+pub struct GoodsUnit {
+    pub good: Good,
+    pub remaining_lifetime: UInt, // interpreted as remaining uses for capital goods.
 }
 
 impl GoodsUnit {
     /// Returns a newly-produced unit of the given good.
     pub fn new(good: &Good) -> Self {
         match good {
-            Good::Berries => GoodsUnit::Berries {
+            Good::Berries => GoodsUnit {
+                good: Good::Berries,
                 remaining_lifetime: 10,
             },
-            Good::Basket => GoodsUnit::Basket { remaining_uses: 10 },
+            Good::Basket => GoodsUnit {
+                good: Good::Basket,
+                remaining_lifetime: 10,
+            },
+            // Good::Berries => GoodsUnit::Berries {
+            //     remaining_lifetime: 10,
+            // },
+            // Good::Basket => GoodsUnit::Basket { remaining_uses: 10 },
         }
     }
 }

--- a/src/goods.rs
+++ b/src/goods.rs
@@ -14,20 +14,6 @@ pub enum Good {
     // Axe,
 }
 
-// // For units of goods, each has a lifetime remaining value before it is destroyed.
-// // For capital goods, (e.g. spear, timber), each has a number of uses remaining before it is destroyed.
-// #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-// pub enum GoodsUnit {
-//     Berries { remaining_lifetime: UInt },
-//     // Fish{ remaining_lifetime: UInt },
-//     Basket { remaining_uses: UInt },
-//     // Spear{ remaining_uses: UInt },
-//     // Smoker{ remaining_uses: UInt },
-//     // Boat{ remaining_uses: UInt },
-//     // Timber,
-//     // Axe,
-// }
-
 // For units of goods, each has a lifetime remaining value before it is destroyed.
 // For capital goods, (e.g. spear, timber), each has a number of uses remaining before it is destroyed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -48,10 +34,6 @@ impl GoodsUnit {
                 good: Good::Basket,
                 remaining_lifetime: 10,
             },
-            // Good::Berries => GoodsUnit::Berries {
-            //     remaining_lifetime: 10,
-            // },
-            // Good::Basket => GoodsUnit::Basket { remaining_uses: 10 },
         }
     }
 }

--- a/src/goods.rs
+++ b/src/goods.rs
@@ -10,6 +10,7 @@ use crate::UInt;
 pub enum Good {
     Berries { remaining_lifetime: UInt },
     // Fish{ remaining_lifetime: UInt },
+    Basket { remaining_uses: UInt },
     // Spear{ remaining_uses: UInt },
     // Smoker{ remaining_uses: UInt },
     // Boat{ remaining_uses: UInt },
@@ -23,6 +24,7 @@ impl Good {
             Good::Berries {
                 remaining_lifetime: _,
             } => true,
+            Good::Basket { remaining_uses: _ } => false,
         }
     }
 }

--- a/src/goods.rs
+++ b/src/goods.rs
@@ -6,8 +6,9 @@ use crate::UInt;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Good {
     Berries,
+    Fish,
     Basket,
-    // Spear,
+    Spear,
     // Smoker,
     // Boat,
     // Timber,
@@ -30,9 +31,17 @@ impl GoodsUnit {
                 good: Good::Berries,
                 remaining_lifetime: 10,
             },
+            Good::Fish => GoodsUnit {
+                good: Good::Fish,
+                remaining_lifetime: 1,
+            },
             Good::Basket => GoodsUnit {
                 good: Good::Basket,
                 remaining_lifetime: 10,
+            },
+            Good::Spear => GoodsUnit {
+                good: Good::Spear,
+                remaining_lifetime: 5,
             },
         }
     }
@@ -42,7 +51,9 @@ impl Good {
     pub fn is_consumer(&self) -> bool {
         match self {
             Good::Berries => true,
+            Good::Fish => true,
             Good::Basket => false,
+            Good::Spear => false,
         }
     }
 
@@ -53,7 +64,12 @@ impl Good {
                 Good::Basket => true,
                 _ => false,
             },
+            Good::Fish => match good {
+                Good::Spear => true,
+                _ => false,
+            },
             Good::Basket => false,
+            Good::Spear => false,
         }
     }
 }

--- a/src/goods.rs
+++ b/src/goods.rs
@@ -2,12 +2,17 @@ use serde::{Deserialize, Serialize};
 
 use crate::UInt;
 
+// A good in the abstract (as opposed to particular units of a good).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-
-// For goods, each has a lifetime remaining value before it is destroyed.
-// For capital goods, (e.g. spear, timber), each has a number of uses remaining before it is destroyed.
-
 pub enum Good {
+    Berries,
+    Basket,
+}
+
+// For units of goods, each has a lifetime remaining value before it is destroyed.
+// For capital goods, (e.g. spear, timber), each has a number of uses remaining before it is destroyed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum GoodsUnit {
     Berries { remaining_lifetime: UInt },
     // Fish{ remaining_lifetime: UInt },
     Basket { remaining_uses: UInt },
@@ -18,13 +23,34 @@ pub enum Good {
     // Axe,
 }
 
+impl GoodsUnit {
+    /// Returns a newly-produced unit of the given good.
+    pub fn new(good: &Good) -> Self {
+        match good {
+            Good::Berries => GoodsUnit::Berries {
+                remaining_lifetime: 10,
+            },
+            Good::Basket => GoodsUnit::Basket { remaining_uses: 10 },
+        }
+    }
+}
+
 impl Good {
     pub fn is_consumer(&self) -> bool {
         match self {
-            Good::Berries {
-                remaining_lifetime: _,
-            } => true,
-            Good::Basket { remaining_uses: _ } => false,
+            Good::Berries => true,
+            Good::Basket => false,
+        }
+    }
+
+    /// Returns true if this good is produced using the given (higher order) good.
+    pub fn is_produced_using(&self, good: Good) -> bool {
+        match self {
+            Good::Berries => match good {
+                Good::Basket => true,
+                _ => false,
+            },
+            Good::Basket => false,
         }
     }
 }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -81,7 +81,8 @@ mod tests {
     fn test_simulation_initialization() {
         let sim = Simulation::new();
         assert_eq!(sim.time, 0);
-        assert!(sim.agents.is_empty());
+        assert!(!sim.agents.is_empty());
+        assert_eq!(sim.agents.len(), 1);
         assert_eq!(sim.config.max_time, 100);
 
         println!(">>>>> {:?}", sim);

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -47,18 +47,7 @@ impl Simulation {
             if !agent.is_alive() {
                 continue; // Skip dead agents
             }
-
             agent.step_forward();
-            // // Select action
-            // let action = agent.choose_action();
-
-            // // Perform action, which updates the agent's stock
-            // agent.act(action);
-
-            // // Consume stock, which updates whether the agent is alive
-            // agent.consume();
-
-            // Degrade the stock
         }
         self.after_step();
     }
@@ -88,25 +77,3 @@ mod tests {
         println!(">>>>> {:?}", sim);
     }
 }
-
-//     fn init(&mut self);
-
-//     // Trade happens in here.
-//     fn after_step(&mut self) {
-//         // Shuffle the vector of agents.
-//         for &mut agent in self.agents().shuffle() {
-//             // Identify the best bilateral trade for this agent.
-
-//             // Execute that trade by updating the stocks of the two agents involved.
-//         }
-//     }
-
-//     fn update(&mut self) {
-//         // Step forward each agent.
-//         for &mut agent in self.agents() {
-//             let action = agent.select_action()
-//             agent.step(action)
-//         }
-//         self.after_step()
-//     }
-// }

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -34,7 +34,7 @@ impl Stock {
     }
 
     /// Takes in the current action of the agent and updates the stock accordingly.
-    fn step_forward(&self, action: Action) -> Stock {
+    pub fn step_forward(&self, action: Action) -> Stock {
         let mut new_stock = Stock::default();
         // Degrade all consumer goods by 1 time unit.
         for (good, quantity) in &self.stock {
@@ -103,6 +103,7 @@ impl Stock {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{UInt, actions::Action, goods::Good};
 
     #[test]
     fn test_add() {
@@ -160,6 +161,38 @@ mod tests {
                 remaining_lifetime: 9
             }),
             Some(&1)
+        );
+    }
+
+    #[test]
+    fn test_step_forward() {
+        let mut stock = HashMap::<Good, UInt>::new();
+        stock.insert(
+            Good::Berries {
+                remaining_lifetime: 10,
+            },
+            5,
+        );
+        let stock = Stock { stock: stock };
+
+        assert_eq!(
+            stock.stock.get(&Good::Berries {
+                remaining_lifetime: 10
+            }),
+            Some(&5)
+        );
+        let stock = stock.step_forward(Action::ProduceBerries);
+        assert_eq!(
+            stock.stock.get(&Good::Berries {
+                remaining_lifetime: 10
+            }),
+            None
+        );
+        assert_eq!(
+            stock.stock.get(&Good::Berries {
+                remaining_lifetime: 9
+            }),
+            Some(&5)
         );
     }
 }

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -98,3 +98,67 @@ impl Stock {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add() {
+        let mut stock = Stock::default();
+        assert_eq!(
+            stock.stock.get(&Good::Berries {
+                remaining_lifetime: 10
+            }),
+            None
+        );
+        stock.add(
+            Good::Berries {
+                remaining_lifetime: 10,
+            },
+            2,
+        );
+        assert_eq!(
+            stock.stock.get(&Good::Berries {
+                remaining_lifetime: 10
+            }),
+            Some(&2)
+        );
+        assert_eq!(
+            stock.stock.get(&Good::Berries {
+                remaining_lifetime: 9
+            }),
+            None
+        );
+        stock.add(
+            Good::Berries {
+                remaining_lifetime: 10,
+            },
+            3,
+        );
+        assert_eq!(
+            stock.stock.get(&Good::Berries {
+                remaining_lifetime: 10
+            }),
+            Some(&5)
+        );
+        assert_eq!(
+            stock.stock.get(&Good::Berries {
+                remaining_lifetime: 9
+            }),
+            None
+        );
+        stock.add(
+            Good::Berries {
+                remaining_lifetime: 9,
+            },
+            1,
+        );
+        assert_eq!(
+            stock.stock.get(&Good::Berries {
+                remaining_lifetime: 9
+            }),
+            Some(&1)
+        );
+    }
+}

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -15,14 +15,14 @@ pub struct Stock {
 }
 
 impl Stock {
-    /// Add a quantify of a good to the stock.
+    /// Add units of a good to the stock.
     pub fn add(&mut self, good: GoodsUnit, quantity: UInt) {
         if let Some(existing_qty) = &self.stock.insert(good, quantity) {
             let _ = &self.stock.insert(good, quantity + *existing_qty);
         }
     }
 
-    /// Remove a quantity of a good from the stock.
+    /// Remove a units of a good from the stock.
     pub fn remove(&mut self, good: &GoodsUnit, quantity: UInt) {
         let existing_qty = &self.stock.get(good);
         match existing_qty.as_ref() {
@@ -52,41 +52,35 @@ impl Stock {
         let mut new_stock = Stock::default();
         // Degrade all consumer goods by 1 time unit.
         for (goods_unit, quantity) in &self.stock {
-            // If the good exists in the stock and is a consumer good, degrade it.
-            // If the remaining_lifetime is 0, remove it from the stock.
-            match goods_unit.good {
-                Good::Berries => {
-                    // TODO: use is_consumer_good() to do this for any consumer good.
-                    // If the good is berries, degrade its remaining lifetime.
-                    // If the new remaining lifetime is zero, remove it from the stock.
+            match goods_unit.good.is_consumer() {
+                // If the good exists in the stock and is a consumer good, degrade it.
+                // If the remaining_lifetime is 0 (after the step), remove it from the stock.
+                true => {
                     if goods_unit.remaining_lifetime > 1 {
                         let new_good = GoodsUnit {
-                            good: Good::Berries,
+                            good: goods_unit.good,
                             remaining_lifetime: goods_unit.remaining_lifetime - 1,
                         };
                         new_stock.stock.insert(new_good, *quantity);
                     }
                 }
-                Good::Basket => {
-                    // TODO: use !is_consumer_good() to do this for any capital good.
-                    match action {
-                        Action::ProduceGood(good) => {
-                            if good.is_produced_using(Good::Basket) {
-                                // If the good is a basket and the action uses the basket,
-                                // degrade its remaining lifetime.
-                                // If the new remaining lifetime is zero, remove it from the stock.
-                                if goods_unit.remaining_lifetime > 1 {
-                                    let new_good = GoodsUnit {
-                                        good: Good::Basket,
-                                        remaining_lifetime: goods_unit.remaining_lifetime - 1,
-                                    };
-                                    new_stock.stock.insert(new_good, *quantity);
-                                } // Handle other goods similarly...
+                // If the good is a capital good and the action makes use of it,
+                // degrade its remaining lifetime.
+                // If the new remaining lifetime is zero, remove it from the stock.
+                false => match action {
+                    Action::ProduceGood(action_good) => {
+                        if action_good.is_produced_using(goods_unit.good) {
+                            if goods_unit.remaining_lifetime > 1 {
+                                let new_good = GoodsUnit {
+                                    good: goods_unit.good,
+                                    remaining_lifetime: goods_unit.remaining_lifetime - 1,
+                                };
+                                new_stock.stock.insert(new_good, *quantity);
                             }
                         }
-                        Action::Leisure => {}
                     }
-                }
+                    Action::Leisure => {}
+                },
             }
         }
         new_stock

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -92,27 +92,6 @@ impl Stock {
         new_stock
     }
 
-    // pub fn next_consumable(&self) -> Option<(&GoodsUnit, &u32)> {
-    //     self.stock
-    //         .iter()
-    //         .filter(|(good, _)| {
-    //             matches!(
-    //                 **good,
-    //                 GoodsUnit::Berries {
-    //                     remaining_lifetime: _
-    //                 }
-    //             )
-    //         })
-    //         .sorted_by_key(|(good, _)| {
-    //             if let GoodsUnit::Berries { remaining_lifetime } = good {
-    //                 *remaining_lifetime
-    //             } else {
-    //                 unreachable!()
-    //             }
-    //         })
-    //         .next()
-    // }
-
     /// Returns a vector of units of consumer goods, ordered by their remaining lifetime.
     pub fn next_consumables(&self) -> Vec<(&GoodsUnit, &u32)> {
         self.stock

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -200,12 +200,20 @@ mod tests {
     #[test]
     fn test_step_forward() {
         let mut stock = HashMap::<GoodsUnit, UInt>::new();
+        // Start with 5 units of berries (lifetime 10) and one basket (lifetime 5).
         stock.insert(
             GoodsUnit {
                 good: Good::Berries,
                 remaining_lifetime: 10,
             },
             5,
+        );
+        stock.insert(
+            GoodsUnit {
+                good: Good::Basket,
+                remaining_lifetime: 5,
+            },
+            1,
         );
         let stock = Stock { stock: stock };
 
@@ -216,7 +224,15 @@ mod tests {
             }),
             Some(&5)
         );
+        assert_eq!(
+            stock.stock.get(&GoodsUnit {
+                good: Good::Basket,
+                remaining_lifetime: 5
+            }),
+            Some(&1)
+        );
         let stock = stock.step_forward(Action::ProduceGood(Good::Berries));
+        // Check the berries have lost one unit of lifetime.
         assert_eq!(
             stock.stock.get(&GoodsUnit {
                 good: Good::Berries,
@@ -230,6 +246,21 @@ mod tests {
                 remaining_lifetime: 9
             }),
             Some(&5)
+        );
+        // Check the basket has been used once.
+        assert_eq!(
+            stock.stock.get(&GoodsUnit {
+                good: Good::Basket,
+                remaining_lifetime: 5
+            }),
+            None
+        );
+        assert_eq!(
+            stock.stock.get(&GoodsUnit {
+                good: Good::Basket,
+                remaining_lifetime: 4
+            }),
+            Some(&1)
         );
     }
 }

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -50,8 +50,20 @@ impl Stock {
                         new_stock.stock.insert(new_good, *quantity);
                     } // Handle other goods similarly...
                 }
+                // Reduce remaining uses of any capital goods involved in the action.
+                Good::Basket { remaining_uses } => {
+                    if action == Action::ProduceBerries {
+                        // The action of producing berries makes use of a
+                        // basket if one is available.
+                        if *remaining_uses > 0 {
+                            let new_good = Good::Basket {
+                                remaining_uses: *remaining_uses - 1,
+                            };
+                            new_stock.stock.insert(new_good, *quantity);
+                        }
+                    }
+                }
             }
-            // TODO: Reduce remaining uses of any capital goods involved in the action.
         }
         new_stock
     }

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -14,7 +14,7 @@ impl Stock {
     /// Add a quantify of a good to the stock.
     pub fn add(&mut self, good: Good, quantity: UInt) {
         if let Some(existing_qty) = &self.stock.insert(good, quantity) {
-            &self.stock.insert(good, quantity + *existing_qty);
+            let _ = &self.stock.insert(good, quantity + *existing_qty);
         }
     }
 
@@ -77,6 +77,7 @@ impl Stock {
             .next()
     }
 
+    /// Returns a vector of units of consumer goods, ordered by their remaining lifetime.
     pub fn next_consumables(&self) -> Vec<(&Good, &u32)> {
         self.stock
             .iter()


### PR DESCRIPTION
- Refactors the `Good` enum into:
  - a simple enum `Good`, representing an abstract good.
  - a struct `GoodsUnit`, representing particular units of a `Good`, with a remaining lifetime.
- Refactors the `Action` enum to have variant `ProduceGood(Good)`.
- Adds a new good: `Good::Basket`.
- Adds new goods: `Good::Fish` and `Good::Spear`.
- Improves the `step_forward` method on the `Stock` by handling all goods generically (as either consumer or not).
- Moves the `step_forward` logic into the `GoodsUnit` struct.